### PR TITLE
yarn tscによるビルド実行時のディレクトリを修正

### DIFF
--- a/src/content/docs/4-機能追加PRの作成/display-name.md
+++ b/src/content/docs/4-機能追加PRの作成/display-name.md
@@ -271,10 +271,10 @@ new integ.IntegTest(app, 'SnsTest', {
 
 ```sh
 # Topicクラスを含めたSNSのコンストラクトを再ビルド
-cd /packages/aws-cdk-lib/aws-sns
+cd /packages/aws-cdk-lib
 yarn tsc
 
-cd packages/@aws-cdk-testing/framework-integ/test/aws-sns
+cd packages/@aws-cdk-testing/framework-integ
 # integ ファイルのビルド/トランスパイルをして、javascript ファイルを生成
 yarn tsc
 # 実際にinteg テストを実行する

--- a/src/content/docs/5-実践課題/tag-mutability.md
+++ b/src/content/docs/5-実践課題/tag-mutability.md
@@ -242,10 +242,10 @@ new integ.IntegTest(app, 'EcrTest', {
 
 ```sh
 # repositoryクラスを含めたecrのコンストラクトを再ビルド
-cd /packages/aws-cdk-lib/aws-ecr
+cd /packages/aws-cdk-lib
 yarn tsc
 
-cd packages/@aws-cdk-testing/framework-integ/test/aws-ecr
+cd packages/@aws-cdk-testing/framework-integ
 # integ ファイルのビルド/トランスパイルをして、javascript ファイルを生成
 yarn tsc
 # 実際にintegテストを実行する


### PR DESCRIPTION
yarn tscは`aws-cdk-lib`や`framework-integ`内のすべてのTSファイルをトランスパイルするので、実行時のディレクトリを合わせて修正した